### PR TITLE
We should have branch level reporting on by default because it shows …

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+branch = True

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
 basepython = python2.7
 usedevelop = True
 commands =
-    {envpython} -m py.test --cov tri.table {posargs}
+    {envpython} -m py.test --cov tri.table --cov-config .coveragerc {posargs}
     {envpython} -m coverage report -m
     {envpython} -m coverage html
 deps =


### PR DESCRIPTION
…unused lambda functions (which it turns out, we have a lot of!)
